### PR TITLE
Suppressing Cryptography Deprecation Warning

### DIFF
--- a/src/process.py
+++ b/src/process.py
@@ -5,10 +5,10 @@ import base64 as b64
 import warnings
 from cryptography.utils import CryptographyDeprecationWarning
 
-# Suppress CryptographyDeprecationWarning specifically
-warnings.filterwarnings("ignore", category=CryptographyDeprecationWarning)
 
-# Your cryptography code here
+warnings.filterwarnings("ignore", category=CryptographyDeprecationWarning) # to suppress Cryptography Deprecation Warning specifically
+
+
 
 # Dictionary of supported algorithms and their key sizes
 SUPPORTED_ALGORITHMS = {

--- a/src/process.py
+++ b/src/process.py
@@ -2,6 +2,13 @@ from cryptography.hazmat.primitives.ciphers import Cipher as CipherClass, algori
 from cryptography.hazmat.primitives import padding as pd
 import os
 import base64 as b64
+import warnings
+from cryptography.utils import CryptographyDeprecationWarning
+
+# Suppress CryptographyDeprecationWarning specifically
+warnings.filterwarnings("ignore", category=CryptographyDeprecationWarning)
+
+# Your cryptography code here
 
 # Dictionary of supported algorithms and their key sizes
 SUPPORTED_ALGORITHMS = {


### PR DESCRIPTION
a minor fix to remove the cryptography deprecation warning in the terminal